### PR TITLE
Add confirmation before bidding

### DIFF
--- a/frontend/src/components/AuctionDetails.js
+++ b/frontend/src/components/AuctionDetails.js
@@ -38,6 +38,9 @@ const AuctionDetails = () => {
 
   const handleBid = async (e) => {
     e.preventDefault();
+    if (!window.confirm(`Place bid of $${parseFloat(bidAmount).toFixed(2)}?`)) {
+      return;
+    }
     const user = JSON.parse(localStorage.getItem("user"));
     const payload = {
       amount: parseFloat(bidAmount),


### PR DESCRIPTION
## Summary
- ask user to confirm before sending bid request

## Testing
- `CI=true npm test --prefix frontend --silent` *(fails: Cannot find module 'react-router-dom')*
- `cd backend && ./mvnw -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68489ef2ca08832baccb9177c1741a17